### PR TITLE
Adicionado tipo de Dado TFieldType.ftExtended

### DIFF
--- a/src/__history/DataSet.Serialize.Export.pas.~1~
+++ b/src/__history/DataSet.Serialize.Export.pas.~1~
@@ -221,7 +221,7 @@ begin
         Result.{$IF DEFINED(FPC)}Add{$ELSE}AddPair{$ENDIF}(LKey, {$IF DEFINED(FPC)}LField.AsWideString{$ELSE}TJSONNumber.Create(LField.AsWideString){$ENDIF});
       TFieldType.ftLargeint:
         Result.{$IF DEFINED(FPC)}Add{$ELSE}AddPair{$ENDIF}(LKey, {$IF DEFINED(FPC)}LField.AsLargeInt{$ELSE}TJSONNumber.Create(LField.AsLargeInt){$ENDIF});
-      {$IF NOT DEFINED(FPC)}TFieldType.ftSingle,TFieldType.ftExtended, {$ENDIF}TFieldType.ftFloat:
+      {$IF NOT DEFINED(FPC)}TFieldType.ftSingle, {$ENDIF}TFieldType.ftFloat:
         Result.{$IF DEFINED(FPC)}Add{$ELSE}AddPair{$ENDIF}(LKey, {$IF DEFINED(FPC)}LField.AsFloat{$ELSE}TJSONNumber.Create(LField.AsFloat){$ENDIF});
       TFieldType.ftString, TFieldType.ftWideString, TFieldType.ftMemo, TFieldType.ftWideMemo, TFieldType.ftGuid, TFieldType.ftFixedChar, TFieldType.ftFixedWideChar:
         Result.{$IF DEFINED(FPC)}Add{$ELSE}AddPair{$ENDIF}(LKey, TJSONString.Create(LField.AsWideString));


### PR DESCRIPTION
Adicionado em DataSet.Serialize.Export. O tipo TFieldType.ftExtended para campo Decimal banco de dados Firebird.     
 {$IF NOT DEFINED(FPC)}TFieldType.ftSingle,TFieldType.ftExtended, {$ENDIF}TFieldType.ftFloat:
        Result.{$IF DEFINED(FPC)}Add{$ELSE}AddPair{$ENDIF}(LKey, {$IF DEFINED(FPC)}LField.AsFloat{$ELSE}TJSONNumber.Create(LField.AsFloat){$ENDIF});